### PR TITLE
Fix broken matrix to quaternion conversion

### DIFF
--- a/src/prime_bullet/geometry.py
+++ b/src/prime_bullet/geometry.py
@@ -206,12 +206,33 @@ class Quaternion(tuple):
     @staticmethod
     def from_matrix(mat):
         """Extracts a quaternion from a >= 3x3 matrix."""
-        w  = np.sqrt(1 + mat[0,0] + mat[1,1] + mat[2,2]) * 0.5
-        w4 = 4 * w
-        x  = (mat[2,1] - mat[1,2]) / w4
-        y  = (mat[0,2] - mat[2,0]) / w4
-        z  = (mat[1,0] - mat[0,1]) / w4
-        return Quaternion(x,y,z,w)
+        tr = mat[0, 0] + mat[1, 1] + mat[2, 2]
+
+        if tr > 0:
+            S = np.sqrt(tr + 1.0) * 2
+            qw = 0.25 * S
+            qx = (mat[2, 1] - mat[1, 2]) / S
+            qy = (mat[0, 2] - mat[2, 0]) / S
+            qz = (mat[1, 0] - mat[0, 1]) / S
+        elif (mat[0, 0] > mat[1, 1]) and (mat[0, 0] > mat[2, 2]):
+            S = np.sqrt(1.0 + mat[0, 0] - mat[1, 1] - mat[2, 2]) * 2
+            qw = (mat[2, 1] - mat[1, 2]) / S
+            qx = 0.25 * S
+            qy = (mat[0, 1] + mat[1, 0]) / S
+            qz = (mat[0, 2] + mat[2, 0]) / S
+        elif mat[1, 1] > mat[2, 2]:
+            S = np.sqrt(1.0 + mat[1, 1] - mat[0, 0] - mat[2, 2]) * 2
+            qw = (mat[0, 2] - mat[2, 0]) / S
+            qx = (mat[0, 1] + mat[1, 0]) / S
+            qy = 0.25 * S
+            qz = (mat[1, 2] + mat[2, 1]) / S
+        else:
+            S = np.sqrt(1.0 + mat[2, 2] - mat[0, 0] - mat[1, 1]) * 2
+            qw = (mat[1, 0] - mat[0, 1]) / S
+            qx = (mat[0, 2] + mat[2, 0]) / S
+            qy = (mat[1, 2] + mat[2, 1]) / S
+            qz = 0.25 * S
+        return Quaternion(qx, qy, qz, qw)
 
     @staticmethod
     def identity():


### PR DESCRIPTION
Hey Adrian,

this PR fixes incorrect (`w=0` could happen) conversion from rotation matrix to quaternions.

See this blog post for more info: https://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/

Thanks,
-Nick